### PR TITLE
Non blocking log export

### DIFF
--- a/features/debug_console.py
+++ b/features/debug_console.py
@@ -1,9 +1,20 @@
 """
 Optimized Debug Console - Efficient logging and monitoring
 """
-from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-                             QTextEdit, QComboBox, QSplitter, QTableWidget, QTableWidgetItem,
-                             QHeaderView)
+
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTextEdit,
+    QComboBox,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
+)
 from PyQt6.QtCore import Qt, QTimer, QThread, QObject, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QFont, QTextCharFormat, QColor, QTextCursor
 import json
@@ -23,15 +34,14 @@ class LogExport(QObject):
     def run(self):
         try:
             with open(self.fname, "w") as f:
-                json.dump(self.log_dict, f, separators=(
-                    ',', ':'))  # Compact JSON
+                json.dump(self.log_dict, f, separators=(",", ":"))  # Compact JSON
         except Exception as e:
             print(e)
         self.finished.emit()
 
 
 class LogEntry:
-    __slots__ = ['timestamp', 'level', 'message', 'node_id', 'node_name']
+    __slots__ = ["timestamp", "level", "message", "node_id", "node_name"]
 
     def __init__(self, timestamp, level, message, node_id=None, node_name=None):
         self.timestamp = timestamp
@@ -123,7 +133,8 @@ class DebugConsole(QWidget):
         self.metrics_table.setColumnCount(2)
         self.metrics_table.setHorizontalHeaderLabels(["Metric", "Value"])
         self.metrics_table.horizontalHeader().setSectionResizeMode(
-            QHeaderView.ResizeMode.Stretch)
+            QHeaderView.ResizeMode.Stretch
+        )
         layout.addWidget(self.metrics_table)
 
         # Update metrics
@@ -140,8 +151,9 @@ class DebugConsole(QWidget):
     def add_log(self, level, message, node_id=None, node_name=None):
         """Optimized log entry addition"""
         level = level.upper()  # Normalize log level to uppercase
-        log_entry = LogEntry(datetime.datetime.now(),
-                             level, message, node_id, node_name)
+        log_entry = LogEntry(
+            datetime.datetime.now(), level, message, node_id, node_name
+        )
 
         self.logs.append(log_entry)  # deque automatically handles maxlen
 
@@ -162,14 +174,14 @@ class DebugConsole(QWidget):
 
         # Filter logs efficiently
         filtered_logs = [
-            log for log in self.logs
-            if (level_filter == "All" or log.level == level_filter) and
-               (node_filter == "All" or log.node_name == node_filter)
+            log
+            for log in self.logs
+            if (level_filter == "All" or log.level == level_filter)
+            and (node_filter == "All" or log.node_name == node_filter)
         ]
 
         # Build display text efficiently
-        log_text = "\n".join(self._format_log_entry(log)
-                             for log in filtered_logs)
+        log_text = "\n".join(self._format_log_entry(log) for log in filtered_logs)
         self.log_display.setPlainText(log_text)
         self.log_display.moveCursor(QTextCursor.MoveOperation.End)
 
@@ -204,13 +216,14 @@ class DebugConsole(QWidget):
                     "level": log.level,
                     "message": log.message,
                     "node_id": log.node_id,
-                    "node_name": log.node_name
+                    "node_name": log.node_name,
                 }
                 for log in self.logs
             ]
 
             def on_thread_complete():
                 self.export_button.setEnabled(True)
+                self.clear_button.setEnabled(True)
                 self.export_button.setText("Export")
                 self.add_log("INFO", f"Logs exported to {filename}")
 
@@ -224,6 +237,7 @@ class DebugConsole(QWidget):
             self.thread.finished.connect(self.thread.deleteLater)
             self.thread.start()
             self.export_button.setEnabled(False)
+            self.clear_button.setEnabled(False)
             self.export_button.setText("Exporting...")
 
         except Exception as e:
@@ -236,16 +250,22 @@ class DebugConsole(QWidget):
         # Calculate metrics
         total_logs = len(self.logs)
         error_count = len([log for log in self.logs if log.level == "ERROR"])
-        warning_count = len(
-            [log for log in self.logs if log.level == "WARNING"])
+        warning_count = len([log for log in self.logs if log.level == "WARNING"])
 
         # Add metrics to table
         metrics = [
             ("Total Logs", str(total_logs)),
             ("Errors", str(error_count)),
             ("Warnings", str(warning_count)),
-            ("Error Rate", f"{(error_count/total_logs*100)             :.1f}%" if total_logs > 0 else "0%"),
-            ("Last Update", datetime.datetime.now().strftime("%H:%M:%S"))
+            (
+                "Error Rate",
+                (
+                    f"{(error_count/total_logs*100)             :.1f}%"
+                    if total_logs > 0
+                    else "0%"
+                ),
+            ),
+            ("Last Update", datetime.datetime.now().strftime("%H:%M:%S")),
         ]
 
         self.metrics_table.setRowCount(len(metrics))
@@ -256,11 +276,19 @@ class DebugConsole(QWidget):
     def log_node_execution(self, node_name, success, execution_time, error=None):
         """Log node execution details"""
         if success:
-            self.add_log("INFO", f"Node '{node_name}' executed successfully in {
-                         execution_time:.3f}s", node_name=node_name)
+            self.add_log(
+                "INFO",
+                f"Node '{node_name}' executed successfully in {
+                         execution_time:.3f}s",
+                node_name=node_name,
+            )
         else:
-            self.add_log("ERROR", f"Node '{node_name}' failed: {
-                         error}", node_name=node_name)
+            self.add_log(
+                "ERROR",
+                f"Node '{node_name}' failed: {
+                         error}",
+                node_name=node_name,
+            )
 
     def log_workflow_start(self, workflow_name):
         """Log workflow start"""
@@ -269,8 +297,14 @@ class DebugConsole(QWidget):
     def log_workflow_end(self, workflow_name, success, total_time):
         """Log workflow completion"""
         if success:
-            self.add_log("INFO", f"Workflow '{
-                         workflow_name}' completed successfully in {total_time:.3f}s")
+            self.add_log(
+                "INFO",
+                f"Workflow '{
+                         workflow_name}' completed successfully in {total_time:.3f}s",
+            )
         else:
-            self.add_log("ERROR", f"Workflow '{
-                         workflow_name}' failed after {total_time:.3f}s")
+            self.add_log(
+                "ERROR",
+                f"Workflow '{
+                         workflow_name}' failed after {total_time:.3f}s",
+            )

--- a/features/debug_console.py
+++ b/features/debug_console.py
@@ -226,12 +226,13 @@ class DebugConsole(QWidget):
                 self.clear_button.setEnabled(True)
                 self.export_button.setText("Export")
                 self.add_log("INFO", f"Logs exported to {filename}")
+                del self.thread
 
             self.thread = QThread()
             self.worker = LogExport(logs_data, filename)
             self.worker.moveToThread(self.thread)
             self.thread.started.connect(self.worker.run)
-            self.worker.finished.connect(on_thread_complete)
+            self.thread.finished.connect(on_thread_complete)
             self.worker.finished.connect(self.thread.quit)
             self.worker.finished.connect(self.worker.deleteLater)
             self.thread.finished.connect(self.thread.deleteLater)

--- a/features/debug_console.py
+++ b/features/debug_console.py
@@ -1,18 +1,38 @@
 """
 Optimized Debug Console - Efficient logging and monitoring
 """
-from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, 
-                             QTextEdit, QComboBox, QSplitter, QTableWidget, QTableWidgetItem, 
+from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+                             QTextEdit, QComboBox, QSplitter, QTableWidget, QTableWidgetItem,
                              QHeaderView)
-from PyQt6.QtCore import Qt, QTimer, pyqtSignal
+from PyQt6.QtCore import Qt, QTimer, QThread, QObject, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QFont, QTextCharFormat, QColor, QTextCursor
 import json
 import datetime
 from collections import deque
 
+
+class LogExport(QObject):
+    finished = pyqtSignal()
+
+    def __init__(self, logs, fname) -> None:
+        super().__init__()
+        self.log_dict = logs
+        self.fname = fname
+
+    @pyqtSlot()
+    def run(self):
+        try:
+            with open(self.fname, "w") as f:
+                json.dump(self.log_dict, f, separators=(
+                    ',', ':'))  # Compact JSON
+        except Exception as e:
+            print(e)
+        self.finished.emit()
+
+
 class LogEntry:
     __slots__ = ['timestamp', 'level', 'message', 'node_id', 'node_name']
-    
+
     def __init__(self, timestamp, level, message, node_id=None, node_name=None):
         self.timestamp = timestamp
         self.level = level
@@ -20,9 +40,10 @@ class LogEntry:
         self.node_id = node_id
         self.node_name = node_name
 
+
 class DebugConsole(QWidget):
     log_added = pyqtSignal(LogEntry)
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.logs = deque(maxlen=500)  # Use deque for efficient append/pop
@@ -32,133 +53,136 @@ class DebugConsole(QWidget):
         self._update_timer.timeout.connect(self.update_metrics)
         self._update_timer.start(5000)  # Update metrics every 5 seconds
         self.init_ui()
-    
+
     def init_ui(self):
-        layout = QVBoxLayout()
-        
+        self.layout = QVBoxLayout()
+
         # Minimalist title
-        title = QLabel("Debug Console")
-        title.setFont(QFont("Poppins", 14, QFont.Weight.Bold))
-        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(title)
-        
+        self.title = QLabel("Debug Console")
+        self.title.setFont(QFont("Poppins", 14, QFont.Weight.Bold))
+        self.title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.layout.addWidget(self.title)
+
         # Compact controls
-        controls_layout = QHBoxLayout()
-        
+        self.controls_layout = QHBoxLayout()
+
         self.level_combo = QComboBox()
         self.level_combo.addItems(["All", "ERROR", "WARNING", "INFO", "DEBUG"])
         self.level_combo.currentTextChanged.connect(self.filter_logs)
-        controls_layout.addWidget(QLabel("Level:"))
-        controls_layout.addWidget(self.level_combo)
-        
+        self.controls_layout.addWidget(QLabel("Level:"))
+        self.controls_layout.addWidget(self.level_combo)
+
         self.node_combo = QComboBox()
         self.node_combo.addItem("All")
         self.node_combo.currentTextChanged.connect(self.filter_logs)
-        controls_layout.addWidget(QLabel("Node:"))
-        controls_layout.addWidget(self.node_combo)
-        
-        clear_button = QPushButton("Clear")
-        clear_button.clicked.connect(self.clear_logs)
-        clear_button.setStyleSheet("QPushButton { padding: 4px 8px; }")
-        controls_layout.addWidget(clear_button)
-        
-        export_button = QPushButton("Export")
-        export_button.clicked.connect(self.export_logs)
-        export_button.setStyleSheet("QPushButton { padding: 4px 8px; }")
-        controls_layout.addWidget(export_button)
-        
-        layout.addLayout(controls_layout)
-        
+        self.controls_layout.addWidget(QLabel("Node:"))
+        self.controls_layout.addWidget(self.node_combo)
+
+        self.clear_button = QPushButton("Clear")
+        self.clear_button.clicked.connect(self.clear_logs)
+        self.clear_button.setStyleSheet("QPushButton { padding: 4px 8px; }")
+        self.controls_layout.addWidget(self.clear_button)
+
+        self.export_button = QPushButton("Export")
+        self.export_button.clicked.connect(self.export_logs)
+        self.export_button.setStyleSheet("QPushButton { padding: 4px 8px; }")
+        self.controls_layout.addWidget(self.export_button)
+
+        self.layout.addLayout(self.controls_layout)
+
         # Main content area
-        splitter = QSplitter(Qt.Orientation.Horizontal)
-        
+        self.splitter = QSplitter(Qt.Orientation.Horizontal)
+
         # Log display
         self.log_display = QTextEdit()
         self.log_display.setReadOnly(True)
         self.log_display.setFont(QFont("Consolas", 10))
-        splitter.addWidget(self.log_display)
-        
+        self.splitter.addWidget(self.log_display)
+
         # Performance metrics
         self.metrics_widget = self.create_metrics_widget()
-        splitter.addWidget(self.metrics_widget)
-        
-        splitter.setSizes([800, 400])
-        layout.addWidget(splitter)
-        
-        self.setLayout(layout)
-    
+        self.splitter.addWidget(self.metrics_widget)
+
+        self.splitter.setSizes([800, 400])
+        self.layout.addWidget(self.splitter)
+
+        self.setLayout(self.layout)
+
     def create_metrics_widget(self):
         """Create performance metrics widget"""
         widget = QWidget()
         layout = QVBoxLayout()
-        
+
         # Title
         title = QLabel("Performance Metrics")
         title.setFont(QFont("Poppins", 14, QFont.Weight.Bold))
         layout.addWidget(title)
-        
+
         # Metrics table
         self.metrics_table = QTableWidget()
         self.metrics_table.setColumnCount(2)
         self.metrics_table.setHorizontalHeaderLabels(["Metric", "Value"])
-        self.metrics_table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        self.metrics_table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.Stretch)
         layout.addWidget(self.metrics_table)
-        
+
         # Update metrics
         self.update_metrics()
-        
+
         widget.setLayout(layout)
         return widget
-    
+
     def setup_logging(self):
         """Setup logging capture"""
         # This would integrate with Python's logging module
         pass
-    
+
     def add_log(self, level, message, node_id=None, node_name=None):
         """Optimized log entry addition"""
         level = level.upper()  # Normalize log level to uppercase
-        log_entry = LogEntry(datetime.datetime.now(), level, message, node_id, node_name)
-        
+        log_entry = LogEntry(datetime.datetime.now(),
+                             level, message, node_id, node_name)
+
         self.logs.append(log_entry)  # deque automatically handles maxlen
-        
+
         # Update node combo if new node
         if node_name and node_name not in self._node_names:
             self._node_names.add(node_name)
             self.node_combo.addItem(node_name)
-        
+
         self.log_added.emit(log_entry)
         self.update_log_display()
-    
+
     def update_log_display(self):
         """Optimized log display update"""
         self.log_display.clear()
-        
+
         level_filter = self.level_combo.currentText()
         node_filter = self.node_combo.currentText()
-        
+
         # Filter logs efficiently
         filtered_logs = [
             log for log in self.logs
             if (level_filter == "All" or log.level == level_filter) and
                (node_filter == "All" or log.node_name == node_filter)
         ]
-        
+
         # Build display text efficiently
-        log_text = "\n".join(self._format_log_entry(log) for log in filtered_logs)
+        log_text = "\n".join(self._format_log_entry(log)
+                             for log in filtered_logs)
         self.log_display.setPlainText(log_text)
         self.log_display.moveCursor(QTextCursor.MoveOperation.End)
-    
+
     def _format_log_entry(self, log):
         """Format a single log entry for display"""
         timestamp_str = log.timestamp.strftime("%H:%M:%S")
         node_info = f" [{log.node_name}]" if log.node_name else ""
         return f"[{timestamp_str}] {log.level}{node_info}: {log.message}"
-    
+
     def filter_logs(self):
         """Filter logs based on current filters"""
         self.update_log_display()
-    
+
     def clear_logs(self):
         """Clear all logs efficiently"""
         self.logs.clear()
@@ -167,13 +191,13 @@ class DebugConsole(QWidget):
         self.node_combo.clear()
         self.node_combo.addItem("All")
         self.update_metrics()
-    
+
     def export_logs(self):
         """Optimized log export"""
         try:
             timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
             filename = f"nodebox_logs_{timestamp}.json"
-            
+
             logs_data = [
                 {
                     "timestamp": log.timestamp.isoformat(),
@@ -184,51 +208,69 @@ class DebugConsole(QWidget):
                 }
                 for log in self.logs
             ]
-            
-            with open(filename, "w") as f:
-                json.dump(logs_data, f, separators=(',', ':'))  # Compact JSON
-            
-            self.add_log("INFO", f"Logs exported to {filename}")
+
+            def on_thread_complete():
+                self.export_button.setEnabled(True)
+                self.export_button.setText("Export")
+                self.add_log("INFO", f"Logs exported to {filename}")
+
+            self.thread = QThread()
+            self.worker = LogExport(logs_data, filename)
+            self.worker.moveToThread(self.thread)
+            self.thread.started.connect(self.worker.run)
+            self.worker.finished.connect(on_thread_complete)
+            self.worker.finished.connect(self.thread.quit)
+            self.worker.finished.connect(self.worker.deleteLater)
+            self.thread.finished.connect(self.thread.deleteLater)
+            self.thread.start()
+            self.export_button.setEnabled(False)
+            self.export_button.setText("Exporting...")
+
         except Exception as e:
             self.add_log("ERROR", f"Export failed: {str(e)}")
-    
+
     def update_metrics(self):
         """Update performance metrics"""
         self.metrics_table.setRowCount(0)
-        
+
         # Calculate metrics
         total_logs = len(self.logs)
         error_count = len([log for log in self.logs if log.level == "ERROR"])
-        warning_count = len([log for log in self.logs if log.level == "WARNING"])
-        
+        warning_count = len(
+            [log for log in self.logs if log.level == "WARNING"])
+
         # Add metrics to table
         metrics = [
             ("Total Logs", str(total_logs)),
             ("Errors", str(error_count)),
             ("Warnings", str(warning_count)),
-            ("Error Rate", f"{(error_count/total_logs*100):.1f}%" if total_logs > 0 else "0%"),
+            ("Error Rate", f"{(error_count/total_logs*100)             :.1f}%" if total_logs > 0 else "0%"),
             ("Last Update", datetime.datetime.now().strftime("%H:%M:%S"))
         ]
-        
+
         self.metrics_table.setRowCount(len(metrics))
         for i, (metric, value) in enumerate(metrics):
             self.metrics_table.setItem(i, 0, QTableWidgetItem(metric))
             self.metrics_table.setItem(i, 1, QTableWidgetItem(value))
-    
+
     def log_node_execution(self, node_name, success, execution_time, error=None):
         """Log node execution details"""
         if success:
-            self.add_log("INFO", f"Node '{node_name}' executed successfully in {execution_time:.3f}s", node_name=node_name)
+            self.add_log("INFO", f"Node '{node_name}' executed successfully in {
+                         execution_time:.3f}s", node_name=node_name)
         else:
-            self.add_log("ERROR", f"Node '{node_name}' failed: {error}", node_name=node_name)
-    
+            self.add_log("ERROR", f"Node '{node_name}' failed: {
+                         error}", node_name=node_name)
+
     def log_workflow_start(self, workflow_name):
         """Log workflow start"""
         self.add_log("INFO", f"Starting workflow: {workflow_name}")
-    
+
     def log_workflow_end(self, workflow_name, success, total_time):
         """Log workflow completion"""
         if success:
-            self.add_log("INFO", f"Workflow '{workflow_name}' completed successfully in {total_time:.3f}s")
+            self.add_log("INFO", f"Workflow '{
+                         workflow_name}' completed successfully in {total_time:.3f}s")
         else:
-            self.add_log("ERROR", f"Workflow '{workflow_name}' failed after {total_time:.3f}s")
+            self.add_log("ERROR", f"Workflow '{
+                         workflow_name}' failed after {total_time:.3f}s")


### PR DESCRIPTION
Fixes #21 
## Improve log export by threading and disabling export button during operation

- Moved the log export process to a secondary thread to keep the UI responsive.  
- Disabled the export button while export is running to prevent multiple exports.

Tested manually by simulating long exports; UI remains responsive and export button properly disabled.
<img width="504" height="221" alt="Screenshot_20251001_185316" src="https://github.com/user-attachments/assets/495d784e-a5b8-4281-8593-d1607e6cca51" />
