### PR TITLE
Revamp Performance tab: real-time system+app metrics, non-blocking UI…

### DIFF
--- a/utils/performance_bus.py
+++ b/utils/performance_bus.py
@@ -1,0 +1,23 @@
+from PyQt6.QtCore import QObject, pyqtSignal
+
+
+class PerformanceEventBus(QObject):
+    """Singleton-like event bus to broadcast app performance metrics.
+
+    Carries aggregated NodeBox-specific metrics so UI components can subscribe
+    without tight coupling to execution code.
+    """
+
+    metrics_signal = pyqtSignal(dict)
+
+
+_instance = None
+
+
+def get_performance_bus() -> PerformanceEventBus:
+    global _instance
+    if _instance is None:
+        _instance = PerformanceEventBus()
+    return _instance
+
+


### PR DESCRIPTION
Title: Revamp Performance Tab in Main Window (#43)
What I changed:
Added utils/performance_bus.py (Qt signal bus) to broadcast app metrics.
Updated utils/node_runner.py to expose non-breaking callbacks and return execution summary: executed_count, error_count, total_duration_s, total_nodes.
Updated canvasmanager/canvas_widget.py to emit NodeBox-specific metrics (active nodes, total nodes, execution time, error count, per-node timings) via the performance bus after runs.
Enhanced features/performance_monitor.py to subscribe to the bus and update NodeBox metrics live; kept psutil-based CPU/Memory/Disk and auto-refresh with QTimer.
Why:
Existing Performance tab was minimal; now it provides actionable insights: CPU/Memory/Disk, active nodes, run duration, error counts, and a rolling history table. Non-blocking updates maintain UI responsiveness.
How to test:
Run app, open Performance tab (lazy-loaded).
Create nodes and click Run in the editor; observe NodeBox metrics update in real time and history rows populating every few cycles.
Start/Stop/Reset controls function without freezing the UI.
Cross-platform:
Uses psutil and PyQt signals/timers; avoids blocking calls, suitable for Windows/Linux/Mac.
Future-ready:
Modular event bus allows adding more metrics or charts later.
Status: Implemented the event bus, instrumented node execution, and wired the Performance tab to subscribe and render metrics. All edits lint clean.