### PR TITLE
fix: prevent duplicate connections when closing windows

### DIFF
--- a/ui/enhanced_main_window.py
+++ b/ui/enhanced_main_window.py
@@ -403,6 +403,11 @@ class EnhancedMainWindow(QWidget):
         self.new_automation_window = NewAutomationWindow(main_window=self)
         self.new_automation_window.show()
 
+    def on_editor_closed(self):
+        print("✅ Editor closed → main window should reappear")
+        self.show()
+
+
     def edit_automation(self, item):
         """Edit selected automation"""
         automation_name = item.text()
@@ -411,10 +416,17 @@ class EnhancedMainWindow(QWidget):
 
         from automation_manager.node_editor_window import NodeEditorWindow
 
-        self.editor_window = NodeEditorWindow(automation_name)
-        self.editor_window.closed.connect(self.show)
-        self.editor_window.show()
+        editor = NodeEditorWindow(automation_name)
+        editor.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+
+        editor.closed.connect(self.on_editor_closed)
+
+        editor.show()
         self.hide()
+
+        self.editor_window = editor
+
+
 
     def open_browse_models_window(self):
         """Open browse models window"""
@@ -449,6 +461,7 @@ class EnhancedMainWindow(QWidget):
             "• Export/Import System\n\n"
             "Built with Python and PyQt6",
         )
+
 
     def closeEvent(self, event):
         """Optimized window close event"""


### PR DESCRIPTION
- Replaced direct connection to self.show with dedicated on_editor_closed slot
- Ensures no signal accumulation across multiple editor instances
- Improves stability and prevents UI flicker