### PR TITLE
Add “View Local Models” Dialog to Manage Ollama Models

### DIFF
--- a/features/model_manager.py
+++ b/features/model_manager.py
@@ -1,0 +1,76 @@
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QListWidget, QPushButton, QMessageBox, QHBoxLayout
+import subprocess
+
+
+class ModelManager(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Local Ollama Models")
+        self.resize(400, 400)
+
+        # Main layout
+        self.layout = QVBoxLayout()
+        self.setLayout(self.layout)
+
+        # Info label
+        self.info_label = QLabel("Locally Downloaded Ollama Models:")
+        self.layout.addWidget(self.info_label)
+
+        # List widget
+        self.model_list = QListWidget()
+        self.layout.addWidget(self.model_list)
+
+        # Button layout
+        self.button_layout = QHBoxLayout()
+        self.delete_button = QPushButton("Delete Selected Model")
+        self.delete_button.clicked.connect(self.delete_model)
+        self.button_layout.addWidget(self.delete_button)
+        self.layout.addLayout(self.button_layout)
+
+        # Load models
+        self.load_models()
+
+    def load_models(self):
+        """Fetch local models and populate the list"""
+        self.model_list.clear()
+        self.delete_button.setEnabled(True)
+
+        try:
+            result = subprocess.run(["ollama", "list"], capture_output=True, text=True, check=True)
+            models = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            if models:
+                self.model_list.addItems(models)
+            else:
+                self.model_list.addItem("No models found!")
+                self.delete_button.setEnabled(False)
+        except FileNotFoundError:
+            self.model_list.addItem("Ollama not installed")
+            self.delete_button.setEnabled(False)
+        except subprocess.CalledProcessError:
+            self.model_list.addItem("Error retrieving models")
+            self.delete_button.setEnabled(False)
+
+    def delete_model(self):
+        """Delete selected model after confirmation"""
+        selected_items = self.model_list.selectedItems()
+        if not selected_items:
+            return
+
+        model_name = selected_items[0].text()
+        if model_name in ["No models found!", "Ollama not installed", "Error retrieving models"]:
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Confirm Delete",
+            f"Are you sure you want to delete model '{model_name}'?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+        )
+
+        if confirm == QMessageBox.StandardButton.Yes:
+            try:
+                subprocess.run(["ollama", "delete", model_name], check=True)
+                QMessageBox.information(self, "Deleted", f"Model '{model_name}' deleted successfully.")
+                self.load_models()  # Refresh the list
+            except subprocess.CalledProcessError:
+                QMessageBox.warning(self, "Error", f"Failed to delete model '{model_name}'.")

--- a/ui/enhanced_main_window.py
+++ b/ui/enhanced_main_window.py
@@ -2,6 +2,8 @@
 Optimized Enhanced Main Window - Minimalist and efficient
 """
 import json
+from features.model_manager import ModelManager
+
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QAction, QFont
@@ -44,6 +46,11 @@ class EnhancedMainWindow(QWidget):
         self.init_ui()
         self.setup_connections()
         self.setup_lazy_loading()
+
+    def open_model_manager_dialog(self):
+        """Open the local models manager dialog"""
+        dialog = ModelManager(self)
+        dialog.exec()
 
     def init_ui(self):
         # Main layout
@@ -126,6 +133,9 @@ class EnhancedMainWindow(QWidget):
         performance_action = QAction("Performance Monitor", self)
         performance_action.triggered.connect(lambda: self.tab_widget.setCurrentIndex(4))
         tools_menu.addAction(performance_action)
+        view_models_action = QAction("View Local Models", self)
+        view_models_action.triggered.connect(self.open_model_manager_dialog)
+        tools_menu.addAction(view_models_action)
 
         # Help menu
         help_menu = self.menu_bar.addMenu("Help")


### PR DESCRIPTION
This PR introduces a new feature that allows users to view and manage their locally downloaded Ollama models directly from the NodeBox application. Previously, users had to rely on terminal commands or manually navigate the filesystem to see installed models or delete them. This improvement brings a user-friendly, integrated solution.
<img width="237" height="206" alt="Local_models_ss1" src="https://github.com/user-attachments/assets/6d594a81-2e6b-45cf-bbf6-97c8bed8a1a4" />
<br>
<img width="500" height="527" alt="local_models_ss2" src="https://github.com/user-attachments/assets/e38bb954-a225-4bc9-8de3-db935f538556" />
