### PR TITLE
docs: Create and populate code reference page

### DIFF
--- a/docs/CodeReference.md
+++ b/docs/CodeReference.md
@@ -1,0 +1,32 @@
+# NodeBox - Code Reference
+
+This document provides a high-level overview of the NodeBox source code structure, key modules, and their purpose.
+
+```markdown
+---
+### `automation_manager/nodeeditor_dialog.py`
+
+This module contains the UI for the Node Editor dialog window.
+
+- **`class NodeEditorDialog(QDialog)`**:
+  - **Description:** A responsive dialog window for editing a node's code. It uses a `QSplitter` layout and handles running the code and saving the results.
+```
+
+```markdown
+---
+### `canvasmanager/canvas_manager.py`
+
+This module manages the main canvas where users build their automation workflows.
+
+- **`class CanvasManager`**:
+  - **Description:** Handles all the logic for the canvas, such as adding nodes, connecting them, and managing the overall state of the workflow.
+```
+
+```markdown
+---
+### `main.py`
+
+This is the main entry point for the NodeBox application.
+
+- **Purpose:** It initializes the main application window and starts the program's event loop.
+```


### PR DESCRIPTION
This pull request creates a new Code Reference page as requested in the issue. The goal of this documentation is to provide a high-level overview of the project's structure to help future contributors get started.

### Key Changes:

* A new `docs/` directory has been created to better organize project documentation.
* A new `CodeReference.md` file has been added inside the `docs/` directory.
* Initial documentation has been added for three key modules:
    * `main.py`
    * `automation_manager/nodeeditor_dialog.py`
    * `canvasmanager/canvas_manager.py`

This provides a solid foundation for the project's code reference that can be expanded in the future.

Closes #39