### PR TITLE
Node Renaming Functionality

### DIFF
--- a/automation_manager/node.py
+++ b/automation_manager/node.py
@@ -1,8 +1,8 @@
 import uuid
 
-from PyQt6.QtCore import QPointF, QRectF, Qt  # type: ignore
-from PyQt6.QtGui import QColor, QFont, QFontMetrics, QPainter, QPen  # type: ignore
-from PyQt6.QtWidgets import QMessageBox, QPushButton, QWidget  # type: ignore
+from PyQt6.QtCore import QPointF, QRectF, Qt
+from PyQt6.QtGui import QColor, QFont, QFontMetrics, QPainter, QPen
+from PyQt6.QtWidgets import QLineEdit, QMessageBox, QMenu, QPushButton, QWidget
 
 from automation_manager.ports import PortWidget
 
@@ -32,6 +32,10 @@ class NodeWidget(QWidget):
         # to track if the node itself is being dragged or not
         self.is_dragging = False
         self.drag_offset = QPointF()
+
+        # to track if the node title is being edited
+        self.is_editing = False
+        self.title_editor = None
 
         self.setMouseTracking(True)
 
@@ -89,6 +93,99 @@ class NodeWidget(QWidget):
 
         self.open_button.clicked.connect(self.on_open_clicked)
         self.delete_button.clicked.connect(self.on_delete_clicked)
+
+    def validate_node_name(self, new_name):
+        """Validate a potential new name for this node."""
+        if not new_name or not new_name.strip():
+            return False, "Node name cannot be empty"
+
+        new_name = new_name.strip()
+
+        # Check for duplicate names in the canvas
+        for node in self.canvas.nodes.values():
+            if node != self and node.title == new_name:
+                return False, f"A node with name '{new_name}' already exists"
+
+        return True, new_name
+
+    def start_title_editing(self):
+        """Start inline editing of the node title."""
+        if self.is_editing:
+            return
+
+        self.is_editing = True
+
+        # Create the line edit widget
+        self.title_editor = QLineEdit(self)
+        self.title_editor.setText(self.title)
+        self.title_editor.setStyleSheet("""
+            QLineEdit {
+                background-color: #1e1e1e;
+                color: #ffffff;
+                border: 2px solid #007acc;
+                border-radius: 4px;
+                padding: 2px 4px;
+                font-family: Arial;
+                font-size: 15px;
+                font-weight: bold;
+                selection-background-color: #007acc;
+            }
+        """)
+
+        title_rect = self.get_title_rect()
+        self.title_editor.setGeometry(title_rect)
+        self.title_editor.selectAll()
+
+        # Connect signals
+        self.title_editor.returnPressed.connect(self.finish_title_editing)
+        self.title_editor.editingFinished.connect(self.cancel_title_editing)
+
+        self.title_editor.installEventFilter(self)
+
+        self.title_editor.show()
+        self.title_editor.setFocus()
+
+        self.update()
+
+    def finish_title_editing(self):
+        """Complete the title editing with the current text."""
+        if not self.is_editing or not self.title_editor:
+            return
+
+        new_title = self.title_editor.text().strip()
+        is_valid, result = self.validate_node_name(new_title)
+
+        if is_valid:
+            self.title = result
+            self.canvas.save_canvas_state()
+            self.cancel_title_editing()
+        else:
+            QMessageBox.warning(self, "Invalid Name", result)
+            self.title_editor.setFocus()
+            self.title_editor.selectAll()
+
+    def cancel_title_editing(self):
+        """Cancel the title editing without saving changes."""
+        if not self.is_editing:
+            return
+
+        self.is_editing = False
+
+        if self.title_editor:
+            self.title_editor.hide()
+            self.title_editor.deleteLater()
+            self.title_editor = None
+
+        self.update()
+
+    def get_title_rect(self):
+        """Get the rectangle where the title is displayed for positioning the editor."""
+        rect = self.rect().adjusted(1, 1, -1, -1)
+        text_height = QFontMetrics(QFont("Arial", 15, QFont.Weight.Bold)).height()
+        text_rect = QRectF(rect)
+        text_rect.setTop(rect.top() + (rect.height() - text_height) / 2)
+        text_rect.setHeight(text_height)
+        return text_rect.toRect()
 
     # on mouse enter or leave it updates visual feedback
     def enterEvent(self, event):
@@ -197,11 +294,13 @@ class NodeWidget(QWidget):
         text_height = QFontMetrics(font).height()
         text_rect.setTop(rect.top() + (rect.height() - text_height) / 2)
 
-        painter.drawText(
-            text_rect,
-            Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignTop,
-            self.title,
-        )
+        # Only draw title if not currently editing
+        if not self.is_editing:
+            painter.drawText(
+                text_rect,
+                Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignTop,
+                self.title,
+            )
 
         # Show/hide buttons based on selection
         if self.selected:
@@ -225,6 +324,36 @@ class NodeWidget(QWidget):
             self.logical_pos = logical_pos
             self.canvas.update_node_position(self.id, self.logical_pos)
             self.update_position()
+
+    def eventFilter(self, obj, event):
+        """Handle events for the title editor."""
+        if obj == self.title_editor and event.type() == event.Type.KeyPress and event.key() == Qt.Key.Key_Escape:
+            self.cancel_title_editing()
+            return True
+        return super().eventFilter(obj, event)
+
+    def mouseDoubleClickEvent(self, event):
+        """Handle double-click to start renaming."""
+        if event.button() == Qt.MouseButton.LeftButton:
+            # Check if double-click is within the title area (not on buttons)
+            local_pos = event.position().toPoint()
+            child = self.childAt(local_pos)
+
+            if child not in (self.delete_button, self.open_button):
+                self.start_title_editing()
+                return
+
+        super().mouseDoubleClickEvent(event)
+
+    def contextMenuEvent(self, event):
+        """Handle right-click context menu."""
+        menu = QMenu(self)
+
+        # Add rename action
+        rename_action = menu.addAction("Rename Node")
+        rename_action.triggered.connect(self.start_title_editing)
+
+        menu.exec(event.globalPos())
 
     def mousePressEvent(self, event):
         if event.button() == Qt.MouseButton.LeftButton:

--- a/canvasmanager/canvas_nodemethods.py
+++ b/canvasmanager/canvas_nodemethods.py
@@ -35,7 +35,6 @@ def open_node(self, node):
     if dlg.exec() == QDialog.accepted:
         data = dlg.result_data
         # Apply changes to node:
-        node.title = data["title"]
         node.code = data["code"]
         node.output_vars = data["outputs"]
         node.update()  # repaint


### PR DESCRIPTION
# Node Renaming Functionality

## Summary
Adds the ability to rename nodes after creation via double-click or right-click context menu, improving workflow organization and maintainability.

## Changes
- **automation_manager/node.py**: Added inline editing UI, validation logic, and event handlers
- **canvasmanager/canvas_nodemethods.py**: Fixed dialog result handling bug

## Features
- Double-click node titles for inline editing
- Right-click context menu with "Rename Node" option
- Input validation preventing empty and duplicate names
- Persistent saving across application sessions
- Maintains existing node connections

## Testing
- Verified double-click and context menu workflows
- Confirmed validation prevents invalid names
- Tested persistence across save/load cycles
- Ensured connection integrity after renaming

## Gif
![Recording 2025-10-12 161203](https://github.com/user-attachments/assets/d02ae0d4-eef5-43f6-9744-5b7cfa30cfe7)

Closes #101 