### PR TITLE
Added basic Python syntax highlighting to NodeEditor

### DIFF
--- a/automation_manager/nodeeditor_dialog.py
+++ b/automation_manager/nodeeditor_dialog.py
@@ -1,4 +1,5 @@
 # ui/node_editor.py
+from ui.python_syntax import PythonHighlighter
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
@@ -77,6 +78,8 @@ class NodeEditorDialog(QDialog):
         self.outputs_edit.setReadOnly(True)
 
         self.code_edit = QTextEdit()
+        PythonHighlighter(self.code_edit.document())
+
         self.terminal_output = QPlainTextEdit()
         self.terminal_output.setReadOnly(True)
 

--- a/automation_manager/python_highlighter.py
+++ b/automation_manager/python_highlighter.py
@@ -1,0 +1,28 @@
+from PyQt5.QtGui import QSyntaxHighlighter, QTextCharFormat, QColor
+from PyQt5.QtCore import QRegExp
+
+class PythonHighlighter(QSyntaxHighlighter):
+    def __init__(self, parent=None):
+        super(PythonHighlighter, self).__init__(parent)
+
+        self.keyword_format = QTextCharFormat()
+        self.keyword_format.setForeground(QColor("#569CD6"))
+
+        keywords = [
+            "def", "class", "import", "from", "return",
+            "if", "elif", "else", "for", "while", "try",
+            "except", "with", "as", "pass", "break", "continue"
+        ]
+
+        self.rules = [
+            (QRegExp(r"\b" + word + r"\b"), self.keyword_format)
+            for word in keywords
+        ]
+
+    def highlightBlock(self, text):
+        for pattern, fmt in self.rules:
+            i = pattern.indexIn(text)
+            while i >= 0:
+                length = pattern.matchedLength()
+                self.setFormat(i, length, fmt)
+                i = pattern.indexIn(text, i + length)

--- a/ui/python_syntax.py
+++ b/ui/python_syntax.py
@@ -1,0 +1,45 @@
+from PyQt6.QtGui import QSyntaxHighlighter, QTextCharFormat, QColor
+from PyQt6.QtCore import QRegularExpression
+
+class PythonHighlighter(QSyntaxHighlighter):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.rules = []
+
+        # ----- Format styles -----
+        keyword_format = QTextCharFormat()
+        keyword_format.setForeground(QColor("#569CD6"))
+        keyword_format.setFontWeight(600)
+
+        string_format = QTextCharFormat()
+        string_format.setForeground(QColor("#CE9178"))
+
+        comment_format = QTextCharFormat()
+        comment_format.setForeground(QColor("#6A9955"))
+
+        # ----- Keywords -----
+        keywords = [
+            "def", "class", "return", "import", "from", "as",
+            "if", "elif", "else", "for", "while",
+            "try", "except", "with", "pass", "break", "continue",
+            "in", "is", "not", "and", "or", "lambda"
+        ]
+
+        for kw in keywords:
+            pattern = QRegularExpression(rf"\\b{kw}\\b")
+            self.rules.append((pattern, keyword_format))
+
+        # ----- Strings -----
+        self.rules.append((QRegularExpression(r'".*"'), string_format))
+        self.rules.append((QRegularExpression(r"'.*'"), string_format))
+
+        # ----- Comments -----
+        self.rules.append((QRegularExpression(r"#.*"), comment_format))
+
+    def highlightBlock(self, text):
+        for pattern, fmt in self.rules:
+            match = pattern.globalMatch(text)
+            while match.hasNext():
+                m = match.next()
+                self.setFormat(m.capturedStart(), m.capturedLength(), fmt)


### PR DESCRIPTION
The Node Editor Dialog (nodeeditor_dialog.py) lacked syntax highlighting, making Python code hard to read and edit.

Added Python Highlighter in python_syntax.py using QSyntaxHighlighter.

Highlighted Python keywords, strings, and comments with distinct colors.

Integrated the highlighter with the Node Editor Dialog’s QTextEdit.